### PR TITLE
New hyprland decoration syntax change

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -60,10 +60,14 @@ decoration {
     # See https://wiki.hyprland.org/Configuring/Variables/ for more
 
     rounding = 10
-    blur = yes
-    blur_size = 7
-    blur_passes = 3
-    blur_new_optimizations = on
+    blur {
+
+        enabled=yes
+      size=3
+      passes=3
+      new_optimizations=1
+      ignore_opacity = true
+    }
     blurls = lockscreen
 
     drop_shadow = yes


### PR DESCRIPTION
Changed the blur syntax to match the new breaking hyprland changes to syntax in the conf file.

I have tested this on my Arch distro, using the same everything from your youtube tutorial.  Without this users get a hyprland error about the new syntax.