### PR TITLE
Resolves the clock error

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -55,7 +55,7 @@
     },
 
     "clock": {
-        "format": "{: %I:%M %p   %a, %b %e}",
+        "format": " {:%I:%M %p   %a, %b %e}",
         "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>"
     },
 


### PR DESCRIPTION
The clock icon cannot be inside the replacement field and also be before the first "%", you now need move it outside of the replacement field, otherwise it will throw an error.

To resolve this I have moved it outside of the replacement field.