### PR TITLE
Fix Waybar temperature (incorrect value of 32°F)

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -95,7 +95,10 @@ dwindle {
 
 master {
     # See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
-    new_is_master = true
+    #new_is_master = true
+	new_status = master
+	new_on_top = 1
+	mfact = 0.5
 }
 
 gestures {

--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -6,28 +6,19 @@
     "passthrough": false,
     "gtk-layer-shell": true,
     "height": 50,
-    "modules-left": ["clock","custom/weather","wlr/workspaces"],
+    "modules-left": ["clock","custom/weather","hyprland/workspaces"],
     "modules-center": ["hyprland/window"],
     "modules-right": ["network", "bluetooth", "temperature","custom/power_profile","battery","backlight","pulseaudio","pulseaudio#microphone","tray"],
     "hyprland/window": {
         "format": "{}"
     },
 
-    "wlr/workspaces": {
-        "disable-scroll": true,
-        "all-outputs": true,
-        "on-click": "activate",
-        "persistent_workspaces": {
-            "1": [],
-            "2": [],
-            "3": [],
-            "4": [],
-            "5": [],
-            "6": [],
-            "7": [],
-            "8": [],
-            "9": [],
-            "10": []
+    "hyprland/workspaces": {
+        "format": "{name}",
+
+        "persistent-workspaces": {
+            "*": 3, // 5 workspaces by default on every monitor
+            "HDMI-A-1": 3 // but only three on HDMI-A-1
         }
     },
     

--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -107,7 +107,7 @@
             "/sys/class/hwmon/hwmon2/temp1_input",
             "/sys/class/thermal/thermal_zone0/temp"
         ],
-        "critical-threshold": 70,
+        "critical-threshold": 80,
         "format-critical": " {temperatureC}°C",
         "format": " {temperatureC}°C"
     },

--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -102,11 +102,16 @@
     },
     
     "temperature": {
-        "thermal-zone": 1,
-        "format": "{temperatureF}°F ",
-        "critical-threshold": 80,
-        "format-critical": "{temperatureC}°C "
+        "thermal-zone": 2,
+        "hwmon-path": [
+            "/sys/class/hwmon/hwmon2/temp1_input",
+            "/sys/class/thermal/thermal_zone0/temp"
+        ],
+        "critical-threshold": 70,
+        "format-critical": " {temperatureC}°C",
+        "format": " {temperatureC}°C"
     },
+
 
     "network": {
         // "interface": "wlp2*", // (Optional) To force the use of this interface


### PR DESCRIPTION
This pull request fixes the **Waybar temperature** display to show the current CPU temperature. Previously, the temperature was stuck at an incorrect value of 32°F and wasn't updating.

To achieve this fix, I referred to the Waybar temperature module documentation: [man page for waybar-temperature](https://man.archlinux.org/man/extra/waybar/waybar-temperature.5.en).

While the previous display might have been in Fahrenheit, I changed it to Celsius.

[FORMAT REPLACEMENTS](https://man.archlinux.org/man/extra/waybar/waybar-temperature.5.en#FORMAT_REPLACEMENTS)
 - {temperatureC}: Temperature in Celsius.
 - {temperatureF}: Temperature in Fahrenheit.
 - {temperatureK}: Temperature in Kelvin.